### PR TITLE
docs: Change visibility of jfrEvents to public, otherwise JfrEventTes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then you can implement tests expecting specific JFR events like so:
 @JfrEventTest
 public class JfrTest {
 
-    public static JfrEvents jfrEvents = new JfrEvents();
+    public JfrEvents jfrEvents = new JfrEvents();
 
     @Test
     @EnableEvent("jdk.GarbageCollection")

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Then you can implement tests expecting specific JFR events like so:
 @JfrEventTest
 public class JfrTest {
 
-    static JfrEvents jfrEvents = new JfrEvents();
+    public static JfrEvents jfrEvents = new JfrEvents();
 
     @Test
     @EnableEvent("jdk.GarbageCollection")


### PR DESCRIPTION
…tExtension can't access it

Avoids the error:
java.lang.RuntimeException: java.lang.IllegalAccessException: class dev.morling.jfrunit.JfrEventTestExtension cannot access a member of class JfrTest with modifiers "static"